### PR TITLE
fix(regex): enforce strict mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,18 @@
 [![Code Style: Google](https://img.shields.io/badge/code%20style-google-blueviolet.svg)](https://github.com/google/gts)
 
 
+### regexFilters 
+
+```typescript
+/*eslint require-unicode-regexp: error */
+
+```
+
+The `u` flag disables the recovering logic Annex B defined. As a result, you can find errors early. This is similar to the strict mode.
+
+Therefore, the `u` flag lets us work better with **regular expressions**.
+
+
 ### safeSend React Wallet
 
 Example Connect / Disconnect button

--- a/src/filter/regexAddress.ts
+++ b/src/filter/regexAddress.ts
@@ -1,1 +1,3 @@
+/*eslint require-unicode-regexp: error */
+// @see {@link https://eslint.org/docs/rules/require-unicode-regexp}
 export const ADDRESS_REGEX = /^0x[0-9a-fA-f]{40}$/


### PR DESCRIPTION
The u flag disables the recovering logic Annex B defined. As a result, you can find errors early. This is similar to the strict mode.

Therefore, the u flag lets us work better with regular expressions.